### PR TITLE
Fix custom command response lookup

### DIFF
--- a/src/events/message/messageCreate.js
+++ b/src/events/message/messageCreate.js
@@ -422,7 +422,7 @@ module.exports = async (client, message) => {
     Name: command,
   });
   if (cmd) {
-    return message.channel.send({ content: cmdx.Responce });
+    return message.channel.send({ content: cmd.Responce });
   }
 
   const cmdx = await CommandsSchema.findOne({


### PR DESCRIPTION
## Summary
- fix custom command handler referencing advanced command response

## Testing
- `node verifyCmdx.js` (proxy to ensure advanced command branch still runs)
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a392efd5548330979e63bb7ac895bb