### PR TITLE
feat: add application setup command

### DIFF
--- a/src/database/models/applicationChannels.js
+++ b/src/database/models/applicationChannels.js
@@ -1,0 +1,10 @@
+const mongoose = require('mongoose');
+
+const Schema = new mongoose.Schema({
+    Guild: String,
+    Channel: String,
+    Log: String,
+    Roles: Array
+});
+
+module.exports = mongoose.model("applicationChannels", Schema);

--- a/src/events/client/interactionCreate.js
+++ b/src/events/client/interactionCreate.js
@@ -6,6 +6,7 @@ const banSchema = require("../../database/models/userBans");
 const verify = require("../../database/models/verify");
 const Commands = require("../../database/models/customCommand");
 const CommandsSchema = require("../../database/models/customCommandAdvanced");
+const applicationSchema = require("../../database/models/applicationChannels");
 module.exports = async (client, interaction) => {
     // Commands
     if (interaction.isCommand() || interaction.isUserContextMenuCommand()) {
@@ -216,6 +217,47 @@ module.exports = async (client, interaction) => {
 
     if (interaction.customId == "Bot_noticeTicket") {
         return require(`${process.cwd()}/src/commands/tickets/notice.js`)(client, interaction);
+    }
+
+    if (interaction.customId == "Bot_apply") {
+        const data = await applicationSchema.findOne({ Guild: interaction.guild.id });
+        if (!data) return client.errNormal({ error: "The application system is not set up!", type: 'ephemeral' }, interaction);
+
+        const modal = new Discord.ModalBuilder()
+            .setCustomId('applyModal')
+            .setTitle('Application')
+            .addComponents(
+                new Discord.ActionRowBuilder().addComponents(
+                    new Discord.TextInputBuilder()
+                        .setCustomId('application')
+                        .setLabel('Why do you want to apply?')
+                        .setStyle(Discord.TextInputStyle.Paragraph)
+                        .setRequired(true)
+                )
+            );
+        await interaction.showModal(modal);
+
+        const submitted = await interaction.awaitModalSubmit({
+            time: 60000,
+            filter: i => i.user.id === interaction.user.id
+        }).catch(() => { });
+
+        if (!submitted) return;
+
+        const response = submitted.fields.getTextInputValue('application');
+        const logChannel = interaction.guild.channels.cache.get(data.Log);
+
+        const embed = new Discord.EmbedBuilder()
+            .setTitle('📨・New application')
+            .addFields(
+                { name: 'User', value: `${interaction.user}`, inline: true },
+                { name: 'Application', value: response }
+            )
+            .setColor(client.config.colors.normal);
+
+        logChannel.send({ content: data.Roles.map(r => `<@&${r}>`).join(' '), embeds: [embed] });
+
+        client.succNormal({ text: `Application successfully submitted!`, type: 'ephemeral' }, submitted);
     }
 }
 

--- a/src/interactions/Command/apply.js
+++ b/src/interactions/Command/apply.js
@@ -1,0 +1,70 @@
+const { CommandInteraction, Client } = require('discord.js');
+const { SlashCommandBuilder, ChannelType } = require('discord.js');
+const Discord = require('discord.js');
+
+const Schema = require("../../database/models/applicationChannels");
+
+module.exports = {
+    data: new SlashCommandBuilder()
+        .setName('apply')
+        .setDescription('Manage the apply system')
+        .addSubcommand(subcommand =>
+            subcommand
+                .setName('setup')
+                .setDescription('Setup the apply system')
+                .addChannelOption(option => option.setName('channel').setDescription('The channel for the apply message').setRequired(true).addChannelTypes(ChannelType.GuildText))
+                .addStringOption(option => option.setName('roles').setDescription('Roles to mention on application logs').setRequired(true))
+                .addChannelOption(option => option.setName('log').setDescription('The channel for the application logs').setRequired(true).addChannelTypes(ChannelType.GuildText))
+        ),
+
+    /**
+     * @param {Client} client
+     * @param {CommandInteraction} interaction
+     * @param {String[]} args
+     */
+    run: async (client, interaction, args) => {
+        await interaction.deferReply({ fetchReply: true });
+        const perms = await client.checkUserPerms({
+            flags: [Discord.PermissionsBitField.Flags.Administrator],
+            perms: [Discord.PermissionsBitField.Flags.Administrator]
+        }, interaction);
+        if (perms == false) return;
+
+        const channel = interaction.options.getChannel('channel');
+        const roles = interaction.options.getString('roles').match(/\d+/g);
+        const log = interaction.options.getChannel('log');
+
+        Schema.findOne({ Guild: interaction.guild.id }, async (err, data) => {
+            if (!data) {
+                new Schema({
+                    Guild: interaction.guild.id,
+                    Channel: channel.id,
+                    Log: log.id,
+                    Roles: roles
+                }).save();
+            }
+            else {
+                data.Channel = channel.id;
+                data.Log = log.id;
+                data.Roles = roles;
+                data.save();
+            }
+        });
+
+        const row = new Discord.ActionRowBuilder().addComponents(
+            new Discord.ButtonBuilder()
+                .setCustomId('Bot_apply')
+                .setLabel('Apply')
+                .setStyle(Discord.ButtonStyle.Primary)
+        );
+
+        const embed = new Discord.EmbedBuilder()
+            .setTitle('📋・Applications')
+            .setDescription('Click the button below to submit your application.')
+            .setColor(client.config.colors.normal);
+
+        channel.send({ embeds: [embed], components: [row] });
+
+        client.succNormal({ text: `Application system successfully setup!`, type: 'ephemeraledit' }, interaction);
+    },
+};


### PR DESCRIPTION
## Summary
- add `/apply setup` command to deploy application panel
- log application submissions with modal form
- store application settings in database

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a390ee40808330b8fe499142c6c5bb