### PR TITLE
Ensure dotenv uses explicit .env file and require its presence

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,17 @@
 const app = require("express")();
 const Discord = require('discord.js');
 const chalk = require('chalk');
-require('dotenv').config('./.env');
+const fs = require('fs');
+const dotenv = require('dotenv');
+const envPath = './.env';
+
+if (!fs.existsSync(envPath)) {
+    console.error(`Missing ${envPath} file. Please create one before starting the bot.`);
+    process.exit(1);
+}
+
+dotenv.config({ path: envPath });
+
 const axios = require('axios');
 const webhook = require("./config/webhooks.json");
 const config = require("./config/bot.js");


### PR DESCRIPTION
## Summary
- Check for the `.env` file and exit with a clear error if missing
- Initialize environment variables using `dotenv.config({ path: './.env' })`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a3a763eb8c83309a78df7933293b5b