### PR TITLE
Fix verification approval role assignment

### DIFF
--- a/src/commands/config/setverifyv2.js
+++ b/src/commands/config/setverifyv2.js
@@ -24,9 +24,6 @@ module.exports = async (client, interaction, args) => {
             }, interaction);
         }
 
-
-    if (enable) {
-
         const data = await Schema.findOne({ Guild: interaction.guild.id });
         if (data) {
             data.Channel = channel.id;
@@ -38,7 +35,6 @@ module.exports = async (client, interaction, args) => {
         }
         else {
             await Schema.create({ Guild: interaction.guild.id, Channel: channel.id, Role: role.id, LogChannel: log.id, AccessRole: accessRole.id });
-
         }
 
         client.succNormal({

--- a/src/events/client/interactionCreate.js
+++ b/src/events/client/interactionCreate.js
@@ -88,36 +88,35 @@ module.exports = async (client, interaction) => {
             try {
                 var image = new Discord.AttachmentBuilder(captcha.JPEGStream, { name: "captcha.jpeg" });
 
-                interaction.reply({ files: [image], fetchReply: true }).then(function (msg) {
-                    const filter = s => s.author.id == interaction.user.id;
+                await interaction.reply({ files: [image] });
+                const msg = await interaction.fetchReply();
+                const filter = s => s.author.id == interaction.user.id;
 
-                    interaction.channel.awaitMessages({ filter, max: 1 }).then(response => {
-                        if (response.first().content === captcha.value) {
-                            response.first().delete();
-                            msg.delete();
+                const response = await interaction.channel.awaitMessages({ filter, max: 1 });
+                if (response.first().content === captcha.value) {
+                    response.first().delete();
+                    msg.delete();
 
-                            client.succNormal({
-                                text: "You have been successfully verified!"
-                            }, interaction.user).catch(error => { })
+                    client.succNormal({
+                        text: "You have been successfully verified!"
+                    }, interaction.user).catch(error => { })
 
-                            var verifyUser = interaction.guild.members.cache.get(interaction.user.id);
-                            verifyUser.roles.add(data.Role);
-                        }
-                        else {
-                            response.first().delete();
-                            msg.delete();
+                    var verifyUser = interaction.guild.members.cache.get(interaction.user.id);
+                    verifyUser.roles.add(data.Role);
+                }
+                else {
+                    response.first().delete();
+                    msg.delete();
 
-                            client.errNormal({
-                                error: "You have answered the captcha incorrectly!",
-                                type: 'editreply'
-                            }, interaction).then(msgError => {
-                                setTimeout(() => {
-                                    msgError.delete();
-                                }, 2000)
-                            })
-                        }
+                    client.errNormal({
+                        error: "You have answered the captcha incorrectly!",
+                        type: 'editreply'
+                    }, interaction).then(msgError => {
+                        setTimeout(() => {
+                            msgError.delete();
+                        }, 2000)
                     })
-                })
+                }
             }
             catch (error) {
                 console.log(error)
@@ -187,7 +186,7 @@ module.exports = async (client, interaction) => {
             }, logChannel);
         }
 
-        return interaction.reply({ content: 'Your verification has been submitted.', ephemeral: true });
+        return interaction.reply({ content: 'Your verification has been submitted.', flags: Discord.MessageFlags.Ephemeral });
     }
 
     if (interaction.isButton() && interaction.customId.startsWith('verifyv2_')) {
@@ -198,13 +197,13 @@ module.exports = async (client, interaction) => {
         if (!data) return;
 
         if (action === 'approve') {
-            const member = interaction.guild.members.cache.get(userId);
+            const member = await interaction.guild.members.fetch(userId).catch(() => null);
             if (member) {
                 const role = interaction.guild.roles.cache.get(data.Role);
-                if (role) member.roles.remove(role).catch(() => { });
+                if (role) await member.roles.remove(role).catch(() => { });
 
                 const access = interaction.guild.roles.cache.get(data.AccessRole);
-                if (access) member.roles.add(access).catch(() => { });
+                if (access) await member.roles.add(access).catch(() => { });
 
             }
             interaction.update({ content: `✅ Approved <@${userId}>`, embeds: interaction.message.embeds, components: [] });


### PR DESCRIPTION
## Summary
- fetch members before approving verification to ensure roles are updated
- replace deprecated interaction replies in verification flow

## Testing
- `node --check src/events/client/interactionCreate.js`
- `node --check src/commands/config/setverifyv2.js`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a4b28cd1fc8330b1e870acb0a88932