### PR TITLE
Allow selfie attachments and verify access role on approval

### DIFF
--- a/src/commands/config/setverifyv2.js
+++ b/src/commands/config/setverifyv2.js
@@ -24,9 +24,6 @@ module.exports = async (client, interaction, args) => {
             }, interaction);
         }
 
-
-    if (enable) {
-
         const data = await Schema.findOne({ Guild: interaction.guild.id });
         if (data) {
             data.Channel = channel.id;
@@ -38,7 +35,6 @@ module.exports = async (client, interaction, args) => {
         }
         else {
             await Schema.create({ Guild: interaction.guild.id, Channel: channel.id, Role: role.id, LogChannel: log.id, AccessRole: accessRole.id });
-
         }
 
         client.succNormal({


### PR DESCRIPTION
## Summary
- prompt users to upload a selfie file or link before submitting verification
- check that access roles are successfully granted on approval and warn if not

## Testing
- `node --check src/events/client/interactionCreate.js`
- `node --check src/commands/config/setverifyv2.js`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a4b28cd1fc8330b1e870acb0a88932