### PR TITLE
Enable multi-line announcement creation via modal

### DIFF
--- a/src/commands/announcement/create.js
+++ b/src/commands/announcement/create.js
@@ -1,12 +1,35 @@
 const Discord = require('discord.js');
 
 module.exports = async (client, interaction, args) => {
-    const message = interaction.options.getString('message');
     const channel = interaction.options.getChannel('channel');
 
-    client.embed({ 
-        title: `📢・Announcement!`, 
-        desc: message 
+    const modal = new Discord.ModalBuilder()
+        .setCustomId('announcementCreate')
+        .setTitle('Create announcement')
+        .addComponents(
+            new Discord.ActionRowBuilder().addComponents(
+                new Discord.TextInputBuilder()
+                    .setCustomId('announcementMessage')
+                    .setLabel('Announcement message')
+                    .setStyle(Discord.TextInputStyle.Paragraph)
+                    .setRequired(true)
+            )
+        );
+
+    await interaction.showModal(modal);
+
+    const submitted = await interaction.awaitModalSubmit({
+        filter: i => i.user.id === interaction.user.id && i.customId === 'announcementCreate',
+        time: 300000
+    }).catch(() => null);
+
+    if (!submitted) return;
+
+    const message = submitted.fields.getTextInputValue('announcementMessage');
+
+    client.embed({
+        title: `📢・Announcement!`,
+        desc: message
     }, channel);
 
     client.succNormal({
@@ -17,8 +40,7 @@ module.exports = async (client, interaction, args) => {
                 value: `${channel} (${channel.name})`
             }
         ],
-        type: 'editreply'
-    }, interaction);
-}
+        type: 'ephemeral'
+    }, submitted);
+};
 
- 

--- a/src/interactions/Command/announcement.js
+++ b/src/interactions/Command/announcement.js
@@ -15,8 +15,7 @@ module.exports = {
             subcommand
                 .setName('create')
                 .setDescription('Make an announcement')
-                .addChannelOption(option => option.setName('channel').setDescription('Select a channel').setRequired(true).addChannelTypes(ChannelType.GuildText).addChannelTypes(ChannelType.GuildNews))
-                .addStringOption(option => option.setName('message').setDescription('Your announcement message').setRequired(true)),
+                .addChannelOption(option => option.setName('channel').setDescription('Select a channel').setRequired(true).addChannelTypes(ChannelType.GuildText).addChannelTypes(ChannelType.GuildNews)),
         )
         .addSubcommand(subcommand =>
             subcommand
@@ -34,15 +33,29 @@ module.exports = {
      */
 
     run: async (client, interaction, args) => {
-        await interaction.deferReply({ fetchReply: true });
-        const perms = await client.checkUserPerms({
-            flags: [Discord.PermissionsBitField.Flags.ManageMessages],
-            perms: [Discord.PermissionsBitField.Flags.ManageMessages]
-        }, interaction)
+        const sub = interaction.options.getSubcommand();
 
-        if (perms == false) return;
+        if (sub === 'create') {
+            if (!interaction.member.permissions.has(Discord.PermissionsBitField.Flags.ManageMessages)) {
+                return client.errMissingPerms({
+                    perms: client.bitfieldToName(Discord.PermissionsBitField.Flags.ManageMessages),
+                    type: 'ephemeral'
+                }, interaction);
+            }
 
-        client.loadSubcommands(client, interaction, args);
+            client.loadSubcommands(client, interaction, args);
+        }
+        else {
+            await interaction.deferReply({ fetchReply: true });
+            const perms = await client.checkUserPerms({
+                flags: [Discord.PermissionsBitField.Flags.ManageMessages],
+                perms: [Discord.PermissionsBitField.Flags.ManageMessages]
+            }, interaction)
+
+            if (perms == false) return;
+
+            client.loadSubcommands(client, interaction, args);
+        }
     },
 };
 


### PR DESCRIPTION
## Summary
- Replace single-line message option with modal input for `/announcement create`
- Bypass automatic deferral for creation and perform permission check within command

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a4fd28076c8330b16424e1d19f5360