### PR TITLE
refactor: replace deprecated fetchReply with withResponse

### DIFF
--- a/src/commands/fun/dinochrome.js
+++ b/src/commands/fun/dinochrome.js
@@ -1,7 +1,7 @@
 
 module.exports = async (client, interaction, args) => {
 
-    let msg = await interaction.editReply({ content: `---------------🦖`, fetchReply: true });
+    let msg = await interaction.editReply({ content: `---------------🦖`, withResponse: true });
     let time = 1 * 1000;
     setTimeout(function () {
         interaction.editReply(`-----------🦖----`);

--- a/src/commands/search/steam.js
+++ b/src/commands/search/steam.js
@@ -2,7 +2,7 @@ const Discord = require('discord.js');
 const pop = require("popcat-wrapper");
 
 module.exports = async (client, interaction, args) => {
-    await interaction.deferReply({ fetchReply: true });
+    await interaction.deferReply({ withResponse: true });
 
     const name = interaction.options.getString('name');
 

--- a/src/handlers/components/embed.js
+++ b/src/handlers/components/embed.js
@@ -251,7 +251,7 @@ module.exports = (client) => {
                 embeds: embeds,
                 content: content,
                 components: components,
-                fetchReply: true
+                withResponse: true
             }).catch(e => { });
         }
         else if (type && type.toLowerCase() == "editreply") {
@@ -259,7 +259,7 @@ module.exports = (client) => {
                 embeds: embeds,
                 content: content,
                 components: components,
-                fetchReply: true
+                withResponse: true
             }).catch(e => { });
         }
         else if (type && type.toLowerCase() == "reply") {
@@ -267,7 +267,7 @@ module.exports = (client) => {
                 embeds: embeds,
                 content: content,
                 components: components,
-                fetchReply: true
+                withResponse: true
             }).catch(e => { });
         }
         else if (type && type.toLowerCase() == "update") {
@@ -275,7 +275,7 @@ module.exports = (client) => {
                 embeds: embeds,
                 content: content,
                 components: components,
-                fetchReply: true
+                withResponse: true
             }).catch(e => { });
         }
         else if (type && type.toLowerCase() == "ephemeraledit") {
@@ -283,7 +283,7 @@ module.exports = (client) => {
                 embeds: embeds,
                 content: content,
                 components: components,
-                fetchReply: true,
+                withResponse: true,
                 ephemeral: true
             }).catch(e => { });
         }
@@ -292,7 +292,7 @@ module.exports = (client) => {
                 embeds: embeds,
                 content: content,
                 components: components,
-                fetchReply: true,
+                withResponse: true,
                 ephemeral: true
             }).catch(e => { });
         }
@@ -301,7 +301,7 @@ module.exports = (client) => {
                 embeds: embeds,
                 content: content,
                 components: components,
-                fetchReply: true
+                withResponse: true
             }).catch(e => { });
         }
     }

--- a/src/handlers/functions/functions.js
+++ b/src/handlers/functions/functions.js
@@ -125,7 +125,7 @@ module.exports = async (client) => {
     }
 
     client.createLeaderboard = async function (title, lb, interaction) {
-        interaction.editReply({ embeds: [await client.generateEmbed(0, 0, lb, title, interaction)], fetchReply: true }).then(async msg => {
+        interaction.editReply({ embeds: [await client.generateEmbed(0, 0, lb, title, interaction)], withResponse: true }).then(async msg => {
             if (lb.length <= 10) return;
 
             let button1 = new Discord.ButtonBuilder()

--- a/src/interactions/Command/activities.js
+++ b/src/interactions/Command/activities.js
@@ -34,7 +34,7 @@ module.exports = {
      */
 
     run: async (client, interaction, args) => {
-        await interaction.deferReply({ fetchReply: true });
+        await interaction.deferReply({ withResponse: true });
         const activity = interaction.options.getString('activity');
 
         const channel = interaction.member.voice.channel;

--- a/src/interactions/Command/afk.js
+++ b/src/interactions/Command/afk.js
@@ -33,7 +33,7 @@ module.exports = {
      */
 
     run: async (client, interaction, args) => {
-        await interaction.deferReply({ fetchReply: true });
+        await interaction.deferReply({ withResponse: true });
         client.loadSubcommands(client, interaction, args);
     },
 };

--- a/src/interactions/Command/announcement.js
+++ b/src/interactions/Command/announcement.js
@@ -46,7 +46,7 @@ module.exports = {
             client.loadSubcommands(client, interaction, args);
         }
         else {
-            await interaction.deferReply({ fetchReply: true });
+            await interaction.deferReply({ withResponse: true });
             const perms = await client.checkUserPerms({
                 flags: [Discord.PermissionsBitField.Flags.ManageMessages],
                 perms: [Discord.PermissionsBitField.Flags.ManageMessages]

--- a/src/interactions/Command/apply.js
+++ b/src/interactions/Command/apply.js
@@ -25,7 +25,7 @@ module.exports = {
      * @param {String[]} args
      */
     run: async (client, interaction, args) => {
-        await interaction.deferReply({ fetchReply: true });
+        await interaction.deferReply({ withResponse: true });
         const perms = await client.checkUserPerms({
             flags: [Discord.PermissionsBitField.Flags.Administrator],
             perms: [Discord.PermissionsBitField.Flags.Administrator]

--- a/src/interactions/Command/automod.js
+++ b/src/interactions/Command/automod.js
@@ -76,7 +76,7 @@ module.exports = {
      */
 
     run: async (client, interaction, args) => {
-        await interaction.deferReply({ fetchReply: true });
+        await interaction.deferReply({ withResponse: true });
         const perms = await client.checkUserPerms({
             flags: [Discord.PermissionsBitField.Flags.ManageMessages],
             perms: [Discord.PermissionsBitField.Flags.ManageMessages]

--- a/src/interactions/Command/autosetup.js
+++ b/src/interactions/Command/autosetup.js
@@ -93,7 +93,7 @@ module.exports = {
      */
 
     run: async (client, interaction, args) => {
-        await interaction.deferReply({ fetchReply: true });
+        await interaction.deferReply({ withResponse: true });
         const perms = await client.checkUserPerms({
             flags: [Discord.PermissionsBitField.Flags.Administrator],
             perms: [Discord.PermissionsBitField.Flags.Administrator]

--- a/src/interactions/Command/birthdays.js
+++ b/src/interactions/Command/birthdays.js
@@ -42,7 +42,7 @@ module.exports = {
      */
 
     run: async (client, interaction, args) => {
-        await interaction.deferReply({ fetchReply: true });
+        await interaction.deferReply({ withResponse: true });
         client.loadSubcommands(client, interaction, args);
     },
 };

--- a/src/interactions/Command/bot.js
+++ b/src/interactions/Command/bot.js
@@ -61,7 +61,7 @@ module.exports = {
      */
 
     run: async (client, interaction, args) => {
-        await interaction.deferReply({ fetchReply: true });
+        await interaction.deferReply({ withResponse: true });
         client.loadSubcommands(client, interaction, args);
     },
 };

--- a/src/interactions/Command/casino.js
+++ b/src/interactions/Command/casino.js
@@ -45,7 +45,7 @@ module.exports = {
      */
 
     run: async (client, interaction, args) => {
-        await interaction.deferReply({ fetchReply: true });
+        await interaction.deferReply({ withResponse: true });
         client.loadSubcommands(client, interaction, args);
     },
 };

--- a/src/interactions/Command/commands.js
+++ b/src/interactions/Command/commands.js
@@ -35,7 +35,7 @@ module.exports = {
      */
 
     run: async (client, interaction, args) => {
-        await interaction.deferReply({ fetchReply: true });
+        await interaction.deferReply({ withResponse: true });
         const perms = await client.checkUserPerms({
             flags: [Discord.PermissionsBitField.Flags.ManageMessages],
             perms: [Discord.PermissionsBitField.Flags.ManageMessages]

--- a/src/interactions/Command/config.js
+++ b/src/interactions/Command/config.js
@@ -92,7 +92,7 @@ module.exports = {
      */
 
     run: async (client, interaction, args) => {
-        await interaction.deferReply({ fetchReply: true });
+        await interaction.deferReply({ withResponse: true });
         client.loadSubcommands(client, interaction, args);
     },
 };

--- a/src/interactions/Command/developers.js
+++ b/src/interactions/Command/developers.js
@@ -85,7 +85,7 @@ module.exports = {
     run: async (client, interaction, args) => {
     
             if (interaction.user.id === process.env.OWNER_ID) {
-                await interaction.deferReply({ fetchReply: true });
+                await interaction.deferReply({ withResponse: true });
                 client.loadSubcommands(client, interaction, args);
             } else {
                 return client.errNormal({

--- a/src/interactions/Command/economy.js
+++ b/src/interactions/Command/economy.js
@@ -164,7 +164,7 @@ module.exports = {
      */
 
     run: async (client, interaction, args) => {
-        await interaction.deferReply({ fetchReply: true });
+        await interaction.deferReply({ withResponse: true });
         client.loadSubcommands(client, interaction, args);
     },
 };

--- a/src/interactions/Command/embed.js
+++ b/src/interactions/Command/embed.js
@@ -21,7 +21,7 @@ module.exports = {
    */
 
   run: async (client, interaction, args) => {
-    await interaction.deferReply({ fetchReply: true });
+    await interaction.deferReply({ withResponse: true });
     const perms = await client.checkPerms(
       {
         flags: [Discord.PermissionsBitField.Flags.ManageMessages],

--- a/src/interactions/Command/family.js
+++ b/src/interactions/Command/family.js
@@ -56,7 +56,7 @@ module.exports = {
      */
 
     run: async (client, interaction, args) => {
-        await interaction.deferReply({ fetchReply: true });
+        await interaction.deferReply({ withResponse: true });
         client.loadSubcommands(client, interaction, args);
     },
 };

--- a/src/interactions/Command/fun.js
+++ b/src/interactions/Command/fun.js
@@ -198,7 +198,7 @@ module.exports = {
      */
 
     run: async (client, interaction, args) => {
-        await interaction.deferReply({ fetchReply: true });
+        await interaction.deferReply({ withResponse: true });
         client.loadSubcommands(client, interaction, args);
     },
 };

--- a/src/interactions/Command/games.js
+++ b/src/interactions/Command/games.js
@@ -81,7 +81,7 @@ module.exports = {
      */
 
     run: async (client, interaction, args) => {
-        await interaction.deferReply({ fetchReply: true });
+        await interaction.deferReply({ withResponse: true });
         client.loadSubcommands(client, interaction, args);
     },
 };

--- a/src/interactions/Command/giveaway.js
+++ b/src/interactions/Command/giveaway.js
@@ -75,7 +75,7 @@ module.exports = {
      */
 
     run: async (client, interaction, args) => {
-        await interaction.deferReply({ fetchReply: true });
+        await interaction.deferReply({ withResponse: true });
         const perms = await client.checkUserPerms({
             flags: [Discord.PermissionsBitField.Flags.ManageMessages],
             perms: [Discord.PermissionsBitField.Flags.ManageMessages]

--- a/src/interactions/Command/guild.js
+++ b/src/interactions/Command/guild.js
@@ -76,7 +76,7 @@ module.exports = {
      */
 
     run: async (client, interaction, args) => {
-        await interaction.deferReply({ fetchReply: true });
+        await interaction.deferReply({ withResponse: true });
         client.loadSubcommands(client, interaction, args);
     },
 };

--- a/src/interactions/Command/images.js
+++ b/src/interactions/Command/images.js
@@ -277,7 +277,7 @@ module.exports = {
      */
 
     run: async (client, interaction, args) => {
-        await interaction.deferReply({ fetchReply: true });
+        await interaction.deferReply({ withResponse: true });
         client.loadSubcommands(client, interaction, args);
     },
 };

--- a/src/interactions/Command/invite.js
+++ b/src/interactions/Command/invite.js
@@ -14,7 +14,7 @@ module.exports = {
      */
 
     run: async (client, interaction, args) => {
-        await interaction.deferReply({ fetchReply: true });
+        await interaction.deferReply({ withResponse: true });
         let row = new Discord.ActionRowBuilder()
             .addComponents(
                 new Discord.ButtonBuilder()

--- a/src/interactions/Command/invites.js
+++ b/src/interactions/Command/invites.js
@@ -45,7 +45,7 @@ module.exports = {
      */
 
     run: async (client, interaction, args) => {
-        await interaction.deferReply({ fetchReply: true });
+        await interaction.deferReply({ withResponse: true });
         client.loadSubcommands(client, interaction, args);
     },
 };

--- a/src/interactions/Command/levels.js
+++ b/src/interactions/Command/levels.js
@@ -70,7 +70,7 @@ module.exports = {
             type: 'ephemeral'
         }, interaction);
 
-        await interaction.deferReply({ fetchReply: true });
+        await interaction.deferReply({ withResponse: true });
         client.loadSubcommands(client, interaction, args);
     },
 };

--- a/src/interactions/Command/messages.js
+++ b/src/interactions/Command/messages.js
@@ -63,7 +63,7 @@ module.exports = {
      */
 
     run: async (client, interaction, args) => {
-        await interaction.deferReply({ fetchReply: true });
+        await interaction.deferReply({ withResponse: true });
         client.loadSubcommands(client, interaction, args);
     },
 };

--- a/src/interactions/Command/moderation.js
+++ b/src/interactions/Command/moderation.js
@@ -129,7 +129,7 @@ module.exports = {
      */
 
     run: async (client, interaction, args) => {
-        await interaction.deferReply({ fetchReply: true });
+        await interaction.deferReply({ withResponse: true });
         client.loadSubcommands(client, interaction, args);
     },
 };

--- a/src/interactions/Command/music.js
+++ b/src/interactions/Command/music.js
@@ -121,7 +121,7 @@ module.exports = {
      */
 
     run: async (client, interaction, args) => {
-        await interaction.deferReply({ fetchReply: true });
+        await interaction.deferReply({ withResponse: true });
         client.checkBotPerms({
             flags: [Discord.PermissionsBitField.Flags.Connect, Discord.PermissionsBitField.Flags.Speak],
             perms: [Discord.PermissionsBitField.Flags.Connect, Discord.PermissionsBitField.Flags.Speak]

--- a/src/interactions/Command/notepad.js
+++ b/src/interactions/Command/notepad.js
@@ -44,7 +44,7 @@ module.exports = {
      */
 
     run: async (client, interaction, args) => {
-        await interaction.deferReply({ fetchReply: true });
+        await interaction.deferReply({ withResponse: true });
         client.loadSubcommands(client, interaction, args);
     },
 };

--- a/src/interactions/Command/profile.js
+++ b/src/interactions/Command/profile.js
@@ -195,7 +195,7 @@ module.exports = {
      */
 
     run: async (client, interaction, args) => {
-        await interaction.deferReply({ fetchReply: true });
+        await interaction.deferReply({ withResponse: true });
         client.loadSubcommands(client, interaction, args);
     },
 };

--- a/src/interactions/Command/purge.js
+++ b/src/interactions/Command/purge.js
@@ -15,7 +15,7 @@ module.exports = {
      */
 
     run: async (client, interaction, args) => {
-        await interaction.deferReply({ fetchReply: true });
+        await interaction.deferReply({ withResponse: true });
         const perms = await client.checkPerms({
             flags: [Discord.PermissionsBitField.Flags.ManageMessages],
             perms: [Discord.PermissionsBitField.Flags.ManageMessages]

--- a/src/interactions/Command/radio.js
+++ b/src/interactions/Command/radio.js
@@ -36,7 +36,7 @@ module.exports = {
      */
 
     run: async (client, interaction, args) => {
-        await interaction.deferReply({ fetchReply: true });
+        await interaction.deferReply({ withResponse: true });
         client.checkBotPerms({
             flags: [Discord.PermissionsBitField.Flags.Connect, Discord.PermissionsBitField.Flags.Speak],
             perms: [Discord.PermissionsBitField.Flags.Connect, Discord.PermissionsBitField.Flags.Speak]

--- a/src/interactions/Command/reactionroles.js
+++ b/src/interactions/Command/reactionroles.js
@@ -54,7 +54,7 @@ module.exports = {
      */
 
     run: async (client, interaction, args) => {
-        await interaction.deferReply({ fetchReply: true });
+        await interaction.deferReply({ withResponse: true });
         const perms = await client.checkPerms({
             flags: [Discord.PermissionsBitField.Flags.ManageRoles],
             perms: [Discord.PermissionsBitField.Flags.ManageRoles]

--- a/src/interactions/Command/report.js
+++ b/src/interactions/Command/report.js
@@ -29,7 +29,7 @@ module.exports = {
      */
 
     run: async (client, interaction, args) => {
-        await interaction.deferReply({ fetchReply: true });
+        await interaction.deferReply({ withResponse: true });
         const webhookClient = new Discord.WebhookClient({
             id: client.webhooks.bugReportLogs.id,
             token: client.webhooks.bugReportLogs.token

--- a/src/interactions/Command/search.js
+++ b/src/interactions/Command/search.js
@@ -106,7 +106,7 @@ module.exports = {
      */
 
     run: async (client, interaction, args) => {
-        await interaction.deferReply({ fetchReply: true });
+        await interaction.deferReply({ withResponse: true });
         client.loadSubcommands(client, interaction, args);
     },
 };

--- a/src/interactions/Command/serverstats.js
+++ b/src/interactions/Command/serverstats.js
@@ -95,7 +95,7 @@ module.exports = {
      */
 
     run: async (client, interaction, args) => {
-        await interaction.deferReply({ fetchReply: true });
+        await interaction.deferReply({ withResponse: true });
         const perms = await client.checkPerms({
             flags: [Discord.PermissionsBitField.Flags.ManageChannels],
             perms: [Discord.PermissionsBitField.Flags.ManageChannels]

--- a/src/interactions/Command/setup.js
+++ b/src/interactions/Command/setup.js
@@ -144,7 +144,7 @@ module.exports = {
      */
 
     run: async (client, interaction, args) => {
-        await interaction.deferReply({ fetchReply: true });
+        await interaction.deferReply({ withResponse: true });
         const perms = await client.checkUserPerms({
             flags: [Discord.PermissionsBitField.Flags.Administrator],
             perms: [Discord.PermissionsBitField.Flags.Administrator]

--- a/src/interactions/Command/soundboard.js
+++ b/src/interactions/Command/soundboard.js
@@ -219,7 +219,7 @@ module.exports = {
      */
 
     run: async (client, interaction, args) => {
-        await interaction.deferReply({ fetchReply: true });
+        await interaction.deferReply({ withResponse: true });
         client.loadSubcommands(client, interaction, args);
     },
 };

--- a/src/interactions/Command/stickymessages.js
+++ b/src/interactions/Command/stickymessages.js
@@ -39,7 +39,7 @@ module.exports = {
      */
 
     run: async (client, interaction, args) => {
-        await interaction.deferReply({ fetchReply: true });
+        await interaction.deferReply({ withResponse: true });
         const perms = await client.checkUserPerms({
             flags: [Discord.PermissionsBitField.Flags.ManageMessages],
             perms: [Discord.PermissionsBitField.Flags.ManageMessages]

--- a/src/interactions/Command/suggestions.js
+++ b/src/interactions/Command/suggestions.js
@@ -38,7 +38,7 @@ module.exports = {
      */
 
     run: async (client, interaction, args) => {
-        await interaction.deferReply({ fetchReply: true });
+        await interaction.deferReply({ withResponse: true });
         client.loadSubcommands(client, interaction, args);
     },
 };

--- a/src/interactions/Command/thanks.js
+++ b/src/interactions/Command/thanks.js
@@ -32,7 +32,7 @@ module.exports = {
      */
 
     run: async (client, interaction, args) => {
-        await interaction.deferReply({ fetchReply: true });
+        await interaction.deferReply({ withResponse: true });
         client.loadSubcommands(client, interaction, args);
     },
 };

--- a/src/interactions/Command/tickets.js
+++ b/src/interactions/Command/tickets.js
@@ -97,7 +97,7 @@ module.exports = {
      */
 
     run: async (client, interaction, args) => {
-        await interaction.deferReply({ fetchReply: true });
+        await interaction.deferReply({ withResponse: true });
         client.loadSubcommands(client, interaction, args);
     },
 };

--- a/src/interactions/Command/tools.js
+++ b/src/interactions/Command/tools.js
@@ -114,7 +114,7 @@ module.exports = {
      */
 
     run: async (client, interaction, args) => {
-        await interaction.deferReply({ fetchReply: true });
+        await interaction.deferReply({ withResponse: true });
         client.loadSubcommands(client, interaction, args);
     },
 };

--- a/src/interactions/Command/voice.js
+++ b/src/interactions/Command/voice.js
@@ -42,7 +42,7 @@ module.exports = {
      */
 
     run: async (client, interaction, args) => {
-        await interaction.deferReply({ fetchReply: true });
+        await interaction.deferReply({ withResponse: true });
         client.loadSubcommands(client, interaction, args);
     },
 };

--- a/src/interactions/ContextMenu/profile.js
+++ b/src/interactions/ContextMenu/profile.js
@@ -62,7 +62,7 @@ module.exports = {
 
         Schema.findOne({ User: user.id }, async (err, data) => {
             if (data) {
-                await interaction.deferReply({ fetchReply: true });
+                await interaction.deferReply({ withResponse: true });
                 let Badges = await model.findOne({ User: user.id });
 
                 let credits = 0;


### PR DESCRIPTION
## Summary
- replace deprecated fetchReply option with withResponse for interaction responses

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a54c5d0040833088e57f0e9bcce781