### PR TITLE
Add yt-dlp plugin for Distube

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,9 @@
       "version": "11.0.0",
       "license": "ISC",
       "dependencies": {
+        "@discordjs/opus": "^0.10.0",
         "@discordjs/voice": "^0.16.0",
+        "@distube/yt-dlp": "^2.0.1",
         "@haileybot/captcha-generator": "^1.7.0",
         "@iamtraction/google-translate": "^2.0.1",
         "@top-gg/sdk": "^3.1.3",
@@ -850,6 +852,40 @@
         "scripts/actions/documentation"
       ]
     },
+    "node_modules/@discordjs/node-pre-gyp": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/@discordjs/node-pre-gyp/-/node-pre-gyp-0.4.5.tgz",
+      "integrity": "sha512-YJOVVZ545x24mHzANfYoy0BJX5PDyeZlpiJjDkUBM/V/Ao7TFX9lcUvCN4nr0tbr5ubeaXxtEBILUrHtTphVeQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "https-proxy-agent": "^5.0.0",
+        "make-dir": "^3.1.0",
+        "node-fetch": "^2.6.7",
+        "nopt": "^5.0.0",
+        "npmlog": "^5.0.1",
+        "rimraf": "^3.0.2",
+        "semver": "^7.3.5",
+        "tar": "^6.1.11"
+      },
+      "bin": {
+        "node-pre-gyp": "bin/node-pre-gyp"
+      }
+    },
+    "node_modules/@discordjs/opus": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/opus/-/opus-0.10.0.tgz",
+      "integrity": "sha512-HHEnSNrSPmFEyndRdQBJN2YE6egyXS9JUnJWyP6jficK0Y+qKMEZXyYTgmzpjrxXP1exM/hKaNP7BRBUEWkU5w==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@discordjs/node-pre-gyp": "^0.4.5",
+        "node-addon-api": "^8.1.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/@discordjs/rest": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-2.5.1.tgz",
@@ -975,6 +1011,32 @@
       "workspaces": [
         "scripts/actions/documentation"
       ]
+    },
+    "node_modules/@distube/yt-dlp": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@distube/yt-dlp/-/yt-dlp-2.0.1.tgz",
+      "integrity": "sha512-9c16lRU6jbyal38UUr5E36+2lp36s0DaJySOtFjuAPgaJkp2xvKvyd+s4rFZSqVQGJO5GOhBiH+HD115SKfKAw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "dargs": "^7.0.0",
+        "undici": "^6.18.2"
+      },
+      "funding": {
+        "url": "https://github.com/skick1234/DisTube?sponsor"
+      },
+      "peerDependencies": {
+        "distube": "5"
+      }
+    },
+    "node_modules/@distube/yt-dlp/node_modules/undici": {
+      "version": "6.21.3",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.3.tgz",
+      "integrity": "sha512-gBLkYIlEnSp8pFbT64yFgGE6UIB9tAkhukC23PmMDCe5Nd+cRqKxSjw5y54MK2AZMgZfJWMaNE4nYUHgi1XEOw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
+      }
     },
     "node_modules/@emnapi/core": {
       "version": "1.4.5",
@@ -3736,6 +3798,15 @@
         "node": ">=14"
       }
     },
+    "node_modules/dargs": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/dargs/-/dargs-7.0.0.tgz",
+      "integrity": "sha512-2iy1EkLdlBzQGvbweYRFxmFath8+K7+AKB0TlhHWkNuH+TmovaMH/Wp7V7R4u7f4SnX3OgLsU9t1NI9ioDnUpg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/dashdash": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
@@ -3981,22 +4052,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=18.17"
-      },
-      "funding": {
-        "url": "https://github.com/skick1234/DisTube?sponsor"
-      },
-      "peerDependencies": {
-        "@discordjs/voice": "*",
-        "discord.js": "14"
-      }
-    },
-    "node_modules/distube/node_modules/undici": {
-      "version": "7.14.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.14.0.tgz",
-      "integrity": "sha512-Vqs8HTzjpQXZeXdpsfChQTlafcMQaaIwnGwLam1wudSSjlJeQ3bw1j+TLPePgrCnCpUXx7Ba5Pdpf5OBih62NQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=20.18.1"
       }
     },
     "node_modules/dom-serializer": {
@@ -6047,6 +6102,15 @@
       },
       "engines": {
         "npm": ">=5.0.0"
+      }
+    },
+    "node_modules/node-addon-api": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.5.0.tgz",
+      "integrity": "sha512-/bRZty2mXUIFY/xU5HLvveNHlswNJej+RnxBjOMkidWfwZzgTbPG1E3K5TOxRLOR+5hX7bSofy8yf1hZevMS8A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
       }
     },
     "node_modules/node-bin-setup": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,9 @@
   "author": "uo1428",
   "license": "ISC",
   "dependencies": {
+    "@discordjs/opus": "^0.10.0",
     "@discordjs/voice": "^0.16.0",
+    "@distube/yt-dlp": "^2.0.1",
     "@haileybot/captcha-generator": "^1.7.0",
     "@iamtraction/google-translate": "^2.0.1",
     "@top-gg/sdk": "^3.1.3",

--- a/src/bot.js
+++ b/src/bot.js
@@ -1,6 +1,7 @@
 const Discord = require('discord.js');
 const fs = require('fs');
 const { DisTube } = require('distube');
+const { YtDlpPlugin } = require('@distube/yt-dlp');
 
 // Discord client
 const client = new Discord.Client({
@@ -51,7 +52,7 @@ const client = new Discord.Client({
 client.distube = new DisTube(client, {
     emitAddSongWhenCreatingQueue: false,
     emitAddListWhenCreatingQueue: false,
-
+    plugins: [new YtDlpPlugin()],
 });
 
 client.distube


### PR DESCRIPTION
## Summary
- include `@distube/yt-dlp` dependency
- hook up `YtDlpPlugin` with DisTube so music commands can stream audio

## Testing
- `npm install --ignore-scripts`
- `npm test` *(fails: Error: no test specified)*
- `npm install` *(fails: Error: connect ENETUNREACH 140.82.113.4:443)*

------
https://chatgpt.com/codex/tasks/task_e_68a56ed94ee08330b4332643f928cdc0